### PR TITLE
build: use rocksdb generated file make_config.mk

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-BUILD_CONFIG = build_config.mk
+BUILD_CONFIG = make_config.mk
 
 all: compile
 


### PR DESCRIPTION
- passes `make test` with & without lz4 present
- check via `otool -L priv/erocksdb.so` if all libraries are present
- closes #6
