### PR TITLE
Build erocksdb using rebar

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-BUILD_CONFIG = make_config.mk
+REBAR ?= ./rebar
 
 all: compile test
 
@@ -8,12 +8,14 @@ get-deps:
 rm-deps:
 	./c_src/build_deps.sh rm-deps
 
+deps:
+	${REBAR} get-deps
+
 compile:
-	./c_src/build_deps.sh
-	PLATFORM_LDFLAGS="`cat c_src/rocksdb/${BUILD_CONFIG} |grep PLATFORM_LDFLAGS| awk -F= '{print $$2}'|sed -e 's/-lsnappy//'`" ./rebar compile
+	${REBAR} compile
 
 test: compile
-	./rebar eunit
+	${REBAR} eunit
 
 clean:
-	./rebar clean
+	${REBAR} clean

--- a/c_src/build_deps.sh
+++ b/c_src/build_deps.sh
@@ -8,7 +8,10 @@ if [ `uname -s` = 'SunOS' -a "${POSIX_SHELL}" != "true" ]; then
 fi
 unset POSIX_SHELL # clear it so if we invoke other scripts, they run as ksh as well
 
-SCRIPT="`pwd`/$0"
+SCRIPTPATH=$( cd $(dirname $0) ; pwd -P )
+SCRIPT=$SCRIPTPATH/${0##*/}
+BASEDIR=$SCRIPTPATH
+BUILD_CONFIG=$BASEDIR/rocksdb/make_config.mk
 
 ROCKSDB_VSN="4.1"
 
@@ -22,7 +25,6 @@ if [ `basename $PWD` != "c_src" ]; then
     cd c_src
 fi
 
-BASEDIR="$PWD"
 
 # detecting gmake and if exists use it
 # if not use make
@@ -71,7 +73,9 @@ case "$1" in
             (cd snappy-$SNAPPY_VSN && ./configure --prefix=$BASEDIR/system --libdir=$BASEDIR/system/lib --with-pic)
         fi
 
-        (cd snappy-$SNAPPY_VSN && $MAKE && $MAKE install)
+        if [ ! -f system/lib/libsnappy.a ]; then
+            (cd snappy-$SNAPPY_VSN && $MAKE && $MAKE install)
+        fi
 
         export CFLAGS="$CFLAGS -I $BASEDIR/system/include"
         export CXXFLAGS="$CXXFLAGS -I $BASEDIR/system/include"

--- a/rebar.config
+++ b/rebar.config
@@ -2,14 +2,14 @@
 
 {port_specs, [{"priv/erocksdb.so", ["c_src/*.cc"]}]}.
 
-{port_env, [
-	     %% Make sure to set -fPIC when compiling rocksdb
-             {"CFLAGS", "$CFLAGS -Wall -O3 -fPIC"},
-             {"CXXFLAGS", "$CXXFLAGS -std=c++11 -Wall -O3 -fPIC"},
-             {"DRV_CFLAGS", "$DRV_CFLAGS -O3 -Wall -I c_src/rocksdb -I c_src/rocksdb/include -I /usr/local/include"},
-             {"DRV_LDFLAGS", "$DRV_LDFLAGS c_src/rocksdb/librocksdb.a c_src/system/lib/libsnappy.a -lstdc++ $PLATFORM_LDFLAGS"}
-             ]}.
+{port_env, [%% Make sure to set -fPIC when compiling rocksdb
+            {"CFLAGS", "$CFLAGS -Wall -O3 -fPIC"},
+            {"CXXFLAGS", "$CXXFLAGS -std=c++11 -Wall -O3 -fPIC"},
+            {"DRV_CFLAGS", "$DRV_CFLAGS -O3 -Wall -I c_src/rocksdb -I c_src/rocksdb/include -I /usr/local/include"},
+            {"DRV_LDFLAGS", "$DRV_LDFLAGS c_src/rocksdb/librocksdb.a c_src/system/lib/libsnappy.a -lstdc++"}]}.
 
-{pre_hooks, [{'get-deps', "c_src/build_deps.sh get-deps"}]}.
+{pre_hooks, [{'get-deps', "c_src/build_deps.sh get-deps"},
+             {compile, "c_src/build_deps.sh"}
+            ]}.
 
 {post_hooks, [{clean, "c_src/build_deps.sh clean"}]}.

--- a/rebar.config.script
+++ b/rebar.config.script
@@ -1,0 +1,17 @@
+%% Build the rocksdb beforehand to retrieve the PLATFORM_LDFLAGS from
+%% c_src/rocksdb/${BUILD_CONFIG} and pass it to rebar compile as an
+%% environment variable
+
+CurrentDir = filename:dirname(SCRIPT).
+
+File = filename:join([CurrentDir, "c_src", "rocksdb", "make_config.mk"]).
+
+Opt = " $(cat " ++ File  ++ " | grep PLATFORM_LDFLAGS | cut -d' ' -f2- | sed -e 's/-lsnappy//')".
+
+Flag = "DRV_LDFLAGS".
+
+{port_env, PortVals} = lists:keyfind(port_env, 1, CONFIG).
+{Flag, Val} = lists:keyfind(Flag, 1, PortVals).
+
+NewPortVals = lists:keyreplace(Flag, 1, PortVals, {Flag, Val ++ Opt}).
+lists:keyreplace(port_env, 1, CONFIG, {port_env, NewPortVals}).


### PR DESCRIPTION
PR to fix building of erocksdb using rebar. This allows us to add the project as a dependency and build it via rebar.
